### PR TITLE
Add a perserve_order feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,14 @@ license = "MIT"
 [badges]
 travis-ci = { repository = "freestrings/jsonpath", branch = "master" }
 
+[features]
+default = []
+preserve_order = ["serde_json/preserve_order"]
+
 [dependencies]
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0", features = ["preserve_order"] }
+serde_json = { version = "1.0" }
 
 [dev-dependencies]
 env_logger = "0.8"


### PR DESCRIPTION
Add a feature to enable serde_json's perserve_order feature. It is disabled by default.

[polars/issues/20208](https://github.com/pola-rs/polars/issues/20208)